### PR TITLE
CCCS-3: Apply Polyphormysm to binary serialization - 

### DIFF
--- a/Src/Emitter/Main.cpp
+++ b/Src/Emitter/Main.cpp
@@ -25,42 +25,42 @@ int main()
 
     // Send one measure
     {
-        Measure msg = *(new Measure(20040501, 23.1, "First measure"));
+        Measure *msg = new Measure(20040501, 23.1, "First measure");
         unsigned char *p = nullptr;
         int sz = 0;
 
         BinaryWrapper::WrapMessage(msg, p, sz);
 
         client.Send(p, sz);
-        std::cout << "Sent: " << msg.To2String() << std::endl;
+        std::cout << "Sent: " << msg->To2String() << std::endl;
     }
 
     sleep(1);
 
     // Send another measure
     {
-        Measure msg = *(new Measure(20040501, 23.7, "Second measure"));
+        Measure *msg = new Measure(20040501, 23.7, "Second measure");
         unsigned char *p = nullptr;
         int sz = 0;
 
         BinaryWrapper::WrapMessage(msg, p, sz);
 
         client.Send(p, sz);
-        std::cout << "Sent: " << msg.To2String() << std::endl;
+        std::cout << "Sent: " << msg->To2String() << std::endl;
     }
 
     sleep(1);
 
     // Send communication closing signal
     {
-        CommTerm msg = *(new CommTerm());
+        CommTerm *msg = new CommTerm();
         unsigned char *p = nullptr;
         int sz = 0;
 
         BinaryWrapper::WrapMessage(msg, p, sz);
 
         client.Send(p, sz);
-        std::cout << "Sent: " << msg.To2String() << std::endl;
+        std::cout << "Sent: " << msg->To2String() << std::endl;
     }
 
     if (client.Stop())

--- a/Src/Library/BinaryWrapper.cpp
+++ b/Src/Library/BinaryWrapper.cpp
@@ -11,12 +11,12 @@ BinaryWrapper::~BinaryWrapper()
 {
 }
 
-void BinaryWrapper::WrapMessage(Measure input, unsigned char *&p, int &sz)
+void BinaryWrapper::WrapMessage(IMessage *input, unsigned char *&p, int &sz)
 {
     unsigned short inner_data_size_label;
     size_t inner_data_size = 0;
     unsigned char *inner_data_content;
-    input.ToBinary(inner_data_content, inner_data_size);
+    input->ToBinary(inner_data_content, inner_data_size);
 
     inner_data_size_label = inner_data_size;
 
@@ -40,7 +40,7 @@ void BinaryWrapper::WrapMessage(Measure input, unsigned char *&p, int &sz)
     outer_data_content[i] = CCCS_LABEL;
     i += 1;
 
-    outer_data_content[i] = (unsigned char)CCCS_TYPE_Measures;
+    outer_data_content[i] = input->TypeSign();
     i += 1;
 
     memcpy(outer_data_content + i, &inner_data_size_label, sizeof(inner_data_size_label));
@@ -54,50 +54,3 @@ void BinaryWrapper::WrapMessage(Measure input, unsigned char *&p, int &sz)
     p = outer_data_content;
     sz = outer_data_size;
 }
-
-
-
-void BinaryWrapper::WrapMessage(CommTerm input, unsigned char *&p, int &sz)
-{
-    unsigned short inner_data_size_label;
-    size_t inner_data_size = 0;
-    unsigned char *inner_data_content;
-    input.ToBinary(inner_data_content, inner_data_size);
-
-    inner_data_size_label = inner_data_size;
-
-    // The binary data structure is:
-    //
-    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // No   Sz Type   Comment
-    // ~~~~|~~|~~~~~~|~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    //  0   01 Label  CCCS_LABEL - Check if it is our message
-    //  1   01 TypeID Id of the data type, from enum CCCS_TYPES
-    //  2   02 Size   The size of the serialized data.
-    //  3   XX Data   The transferring data
-    //  N   01 1      Terminator
-
-    int outer_data_size = inner_data_size + 5;
-    unsigned char *outer_data_content = (unsigned char *)
-        calloc(outer_data_size, sizeof(unsigned char));
-
-    int i = 0;
-
-    outer_data_content[i] = CCCS_LABEL;
-    i += 1;
-
-    outer_data_content[i] = (unsigned char)CCCS_TYPE_Conn_Term;
-    i += 1;
-
-    memcpy(outer_data_content + i, &inner_data_size_label, sizeof(inner_data_size_label));
-    i += sizeof(inner_data_size_label);
-
-    memcpy(outer_data_content + i, inner_data_content, inner_data_size);
-    i += inner_data_size;
-
-    outer_data_content[i] = 1;
-
-    p = outer_data_content;
-    sz = outer_data_size;
-}
-

--- a/Src/Library/BinaryWrapper.hpp
+++ b/Src/Library/BinaryWrapper.hpp
@@ -1,5 +1,6 @@
 #include "Measure.hpp"
 #include "CommTerm.hpp"
+#include "IMessage.hpp"
 
 #ifndef BINARY_WR
 #define BINARY_WR
@@ -12,8 +13,7 @@ public:
     BinaryWrapper();
     ~BinaryWrapper();
 
-    static void WrapMessage(Measure input, unsigned char *&p, int &sz);
-    static void WrapMessage(CommTerm input, unsigned char *&p, int &sz);
+    static void WrapMessage(IMessage *input, unsigned char *&p, int &sz);
 };
 
 #endif

--- a/Src/Library/IMessage.hpp
+++ b/Src/Library/IMessage.hpp
@@ -27,6 +27,8 @@ public:
 
         return std::string(str);
     }
+    
+    virtual void ToBinary(unsigned char *&p, size_t &sz) = 0;
 
     IMessage(unsigned char t) { type_sign = t; }
     ~IMessage() { ; }

--- a/Src/Library/Measure.hpp
+++ b/Src/Library/Measure.hpp
@@ -13,7 +13,7 @@ private:
     std::time_t time;
     double temperature;
     std::string circumstances;
-    char* str_circ;
+    char *str_circ = nullptr;
 
     void set_circ(const char *pstr);
 


### PR DESCRIPTION
Using addresses instead of references allows the use of base base-type addresses to transfer the driver objects safely.

Closes #3 