### PR TITLE
Structure Project Makefiles

### DIFF
--- a/Src/Collector/Makefile
+++ b/Src/Collector/Makefile
@@ -1,6 +1,12 @@
 BINDIR := ./Bin
-SOURCE := ./Main.cpp ./CollectorService.cpp ../Library/Server.cpp ../Library/Measure.cpp ../Library/CommTerm.cpp ../Library/BinaryWrapper.cpp
 BINARY := $(addprefix $(BINDIR)/, collector)
+
+LIB_SIGNALS := ../Library/Measure.cpp ../Library/CommTerm.cpp
+LIB_NETWORK := ../Library/Server.cpp
+SOURCE := ./Main.cpp \
+		  $(LIB_NETWORK) \
+		  $(LIB_SIGNALS) \
+          ./CollectorService.cpp \
 
 $(BINARY): $(SOURCE)
 	g++ -g -o $(BINARY) $(SOURCE)

--- a/Src/Emitter/Makefile
+++ b/Src/Emitter/Makefile
@@ -1,6 +1,11 @@
 BINDIR := ./Bin
-SOURCE := ./Main.cpp ../Library/Client.cpp ../Library/Measure.cpp ../Library/CommTerm.cpp ../Library/BinaryWrapper.cpp
 BINARY := $(addprefix $(BINDIR)/, emitter)
+
+LIB_SIGNALS := ../Library/Measure.cpp ../Library/CommTerm.cpp ../Library/BinaryWrapper.cpp
+LIB_NETWORK := ../Library/Client.cpp
+SOURCE := ./Main.cpp \
+		  $(LIB_NETWORK) \
+		  $(LIB_SIGNALS) \
 
 $(BINARY): $(SOURCE)
 	g++ -g -o $(BINARY) $(SOURCE)


### PR DESCRIPTION
## Structure Project Makefiles

Currently, the source lists of makefiles are too long.
It can be good to group them into groups and to split them into strings.

Closes #9 